### PR TITLE
getSongs function

### DIFF
--- a/src/api/interfaces/spotifyInterfaces.ts
+++ b/src/api/interfaces/spotifyInterfaces.ts
@@ -1,0 +1,99 @@
+export interface Track {
+	album: Album;
+	artists: Artist[];
+	available_markets: string[];
+	disc_number: number;
+	duration_ms: number;
+	explicit: boolean;
+	external_ids: {
+		isrc: string;
+		ean: string;
+		upc: string;
+	};
+	external_urls: {
+		spotify: string;
+	};
+	href: string;
+	id: string;
+	is_playable: boolean;
+	linked_from: object;
+	restrictions: {
+		reason: string;
+	};
+	name: string;
+	popularity: number;
+	preview_url: string;
+	track_number: number;
+	type: string;
+	uri: string;
+	is_local: boolean;
+}
+
+export interface Album {
+	album_type: string;
+	total_tracks: number;
+	available_markets: string[];
+	external_urls: {
+		spotify: string;
+	};
+	href: string;
+	id: string;
+	images: {
+		url: string;
+		height: number;
+		width: number;
+	}[];
+	name: string;
+	release_date: string;
+	release_date_precision: string;
+	restrictions: {
+		reason: string;
+	};
+	type: string;
+	uri: string;
+	copyrights: {
+		text: string;
+		type: string;
+	}[];
+	external_ids: {
+		isrc: string;
+		ean: string;
+		upc: string;
+	};
+	genres: string[];
+	label: string;
+	popularity: number;
+	album_group: string;
+	artists: {
+		external_urls: {
+			spotify: string;
+		};
+		href: string;
+		id: string;
+		name: string;
+		type: string;
+		uri: string;
+	}[];
+}
+
+export interface Artist {
+	external_urls: {
+		spotify: string;
+	};
+	followers: {
+		href: string;
+		total: number;
+	};
+	genres: string[];
+	href: string;
+	id: string;
+	images: {
+		url: string;
+		height: number;
+		width: number;
+	}[];
+	name: string;
+	popularity: number;
+	type: string;
+	uri: string;
+}

--- a/src/api/spotify.ts
+++ b/src/api/spotify.ts
@@ -1,3 +1,6 @@
+import type { SongDetails } from 'src/types/Details';
+import type { Track, Artist } from 'src/api/interfaces/spotifyInterfaces';
+
 export function getUserData() {
 	const xhr = new XMLHttpRequest();
 	xhr.open('GET', `https://api.spotify.com/v1/me`, true);
@@ -11,5 +14,30 @@ export function getUserData() {
 			user_id: `${responseData.id}`
 		});
 		return data;
+	};
+}
+
+export function getSongs(params: string) {
+	const xhr = new XMLHttpRequest();
+	xhr.open('GET', `https://api.spotify.com/v1/recommendations?${params}`, true);
+	xhr.setRequestHeader('Content-Type', 'application/json');
+	xhr.setRequestHeader('Authorization', `Bearer ${localStorage.getItem('access_token')}`);
+	xhr.send(null);
+	xhr.onload = () => {
+		const responseData = JSON.parse(xhr.responseText);
+		const songArray = responseData.items;
+		const songList: SongDetails[] = [];
+		const artists: string[] = responseData.artists.map((artist: Artist) => artist.name);
+		songArray.array.forEach((song: Track) => {
+			const newSong: SongDetails = {
+				songid: `${song.id}`,
+				title: `${song.name}`,
+				artists: artists,
+				image: song.album.images[0].url,
+				previewAudio: `${song.preview_url ? song.preview_url : null}`
+			};
+			songList.push(newSong);
+		});
+		return songList;
 	};
 }

--- a/tests/api/spotify.test.ts
+++ b/tests/api/spotify.test.ts
@@ -1,7 +1,7 @@
 import { server } from '../mocks/browser';
 import { describe, it, expect, afterAll, afterEach, beforeAll } from 'vitest';
 
-import { getUserData } from '../../src/api/spotify';
+import { getUserData, getSongs } from '../../src/api/spotify';
 
 beforeAll(() => {
 	server.listen();
@@ -22,5 +22,20 @@ describe('spotify endpoint tests', () => {
 			display_name: 'mockDisplayName',
 			user_id: 'mockId'
 		});
+	});
+	it('getSongs', () => {
+		const params = new URLSearchParams({
+			mock: 'mockParams'
+		});
+		const result = getSongs(params.toString());
+		expect(result).toEqual([
+			{
+				songid: 'mockId',
+				title: 'mockTitle',
+				artists: ['mockName'],
+				image: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228',
+				previewAudio: 'mockPreviewUrl'
+			}
+		]);
 	});
 });

--- a/tests/mocks/browser.ts
+++ b/tests/mocks/browser.ts
@@ -33,6 +33,129 @@ const server = setupServer(
 				uri: 'string'
 			})
 		);
+	}),
+	rest.get('https://api.spotify.com/v1/recommendations?', (req, res, ctx) => {
+		return res(
+			ctx.json({
+				seeds: [
+					{
+						afterFilteringSize: 0,
+						afterRelinkingSize: 0,
+						href: 'string',
+						id: 'string',
+						initialPoolSize: 0,
+						type: 'string'
+					}
+				],
+				tracks: [
+					{
+						album: {
+							album_type: 'compilation',
+							total_tracks: 9,
+							available_markets: ['CA', 'BR', 'IT'],
+							external_urls: {
+								spotify: 'string'
+							},
+							href: 'string',
+							id: '2up3OPMp9Tb4dAKM2erWXQ',
+							images: [
+								{
+									url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228',
+									height: 300,
+									width: 300
+								}
+							],
+							name: 'string',
+							release_date: '1981-12',
+							release_date_precision: 'year',
+							restrictions: {
+								reason: 'market'
+							},
+							type: 'album',
+							uri: 'spotify:album:2up3OPMp9Tb4dAKM2erWXQ',
+							copyrights: [
+								{
+									text: 'string',
+									type: 'string'
+								}
+							],
+							external_ids: {
+								isrc: 'string',
+								ean: 'string',
+								upc: 'string'
+							},
+							genres: ['Egg punk', 'Noise rock'],
+							label: 'string',
+							popularity: 0,
+							album_group: 'compilation',
+							artists: [
+								{
+									external_urls: {
+										spotify: 'string'
+									},
+									href: 'string',
+									id: 'string',
+									name: 'string',
+									type: 'artist',
+									uri: 'string'
+								}
+							]
+						},
+						artists: [
+							{
+								external_urls: {
+									spotify: 'string'
+								},
+								followers: {
+									href: 'string',
+									total: 0
+								},
+								genres: ['Prog rock', 'Grunge'],
+								href: 'string',
+								id: 'string',
+								images: [
+									{
+										url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228',
+										height: 300,
+										width: 300
+									}
+								],
+								name: 'mockName',
+								popularity: 0,
+								type: 'artist',
+								uri: 'string'
+							}
+						],
+						available_markets: ['string'],
+						disc_number: 0,
+						duration_ms: 0,
+						explicit: false,
+						external_ids: {
+							isrc: 'string',
+							ean: 'string',
+							upc: 'string'
+						},
+						external_urls: {
+							spotify: 'string'
+						},
+						href: 'string',
+						id: 'mockId',
+						is_playable: false,
+						linked_from: {},
+						restrictions: {
+							reason: 'string'
+						},
+						name: 'mockTitle',
+						popularity: 0,
+						preview_url: 'mockPreviewUrl',
+						track_number: 0,
+						type: 'track',
+						uri: 'string',
+						is_local: false
+					}
+				]
+			})
+		);
 	})
 );
 


### PR DESCRIPTION
## What
- getSongs function implemented
- test for getSongs function

## Why
- getSongs function used to retrieve song recommendations from Spotify endpoint
- test to ensure function works as intended

## Impact
- Will customer experience be significantly altered? No
- Does the code change cover more than one task? No

## Testing
- tested locally by running `npm run dev`
