### PR TITLE
Card audio bug fix

### DIFF
--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -11,7 +11,11 @@
 	let audio: HTMLAudioElement;
 
 	onMount(() => {
-		audio = new Audio(songDetails.previewAudio);
+		if (songDetails.previewAudio !== 'null') {
+			audio = new Audio(songDetails.previewAudio);
+		} else {
+			audio = new Audio();
+		}
 	});
 	function renderArtists(): string {
 		const { artists } = songDetails;
@@ -25,7 +29,7 @@
 		return artistsOneline;
 	}
 	function toggleExpand(): void {
-		if (expand) {
+		if (expand && audio) {
 			audio.pause();
 		}
 		savedPosition = trackPosition;

--- a/src/components/Controls.svelte
+++ b/src/components/Controls.svelte
@@ -69,18 +69,23 @@
 
 <div class="controls">
 	<div class="controlButtons">
-		<button class="playPause" on:click|stopPropagation={toggleAudio}>
-			<span class="material-icons">
-				{currStatus === status.PLAY ? 'pause' : 'play_arrow'}
-			</span>
-		</button>
-		<input
-			type="range"
-			max="30"
-			value={position}
-			class="trackPlaceholder"
-			on:click|stopPropagation|self={seek}
-		/>
+		{#if audio.src !== ''}
+			<button class="playPause" on:click|stopPropagation={toggleAudio}>
+				<span class="material-icons">
+					{currStatus === status.PLAY ? 'pause' : 'play_arrow'}
+				</span>
+			</button>
+			<input
+				type="range"
+				max="30"
+				value={position}
+				class="trackPlaceholder"
+				on:click|stopPropagation|self={seek}
+			/>
+		{:else}
+			<div class="noAudioText">Preview not available</div>
+		{/if}
+
 		<button on:click|stopPropagation={handleLikeSong}>
 			<span class={!liked ? 'material-symbols-outlined' : 'material-icons'}>favorite</span>
 		</button>

--- a/static/css/card.css
+++ b/static/css/card.css
@@ -64,3 +64,10 @@ img {
 	height: 0.2rem;
 	margin-right: 0.5rem;
 }
+.noAudioText {
+	width: 12rem;
+	color: var(--accent2);
+	font-family: var(--body);
+	font-size: 1rem;
+	font-weight: bold;
+}


### PR DESCRIPTION
## What
- fixed card bug for no preview audio
- If there is no preview audio, text will appear in place of controls to let users know

## Why
- previously did not handle if there was no preview audio provided by Spotify

## Impact
- Will customer experience be significantly altered? Yes
- Does the code change cover more than one task? No

## Testing
- tested locally by running `npm run dev`
