### PR TITLE
getUserData

### DIFF
--- a/src/api/spotify/auth.ts
+++ b/src/api/spotify/auth.ts
@@ -91,7 +91,6 @@ export async function exchangeToken(code: string) {
 			storedObj.refresh_token = data.refresh_token;
 			storedObj.access_token = data.access_token;
 			localStorage.setItem('ViBE', JSON.stringify(storedObj));
-			window.location.replace(`${url}`);
 		}
 	} else {
 		alert(response.statusText);

--- a/src/api/spotify/service.ts
+++ b/src/api/spotify/service.ts
@@ -3,22 +3,27 @@ import type { Song, Artist, LocalStorage } from '../spotify/types';
 import fetch from 'cross-fetch';
 
 export async function getUserData() {
-	const accessToken = localStorage.getItem('access_token');
-	const response = await fetch('https://api.spotify.com/v1/me', {
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${accessToken}`
+	try {
+		const storedValue: string | null = localStorage.getItem('ViBE');
+		if (storedValue !== null) {
+			const obj: LocalStorage = JSON.parse(storedValue);
+			const accessToken = obj.access_token;
+			const response = await fetch('https://api.spotify.com/v1/me', {
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`
+				}
+			});
+			if (!response.ok) {
+				console.log('getUserData error');
+			}
+			const responseData = await response.json();
+			return responseData;
 		}
-	});
-	if (!response.ok) {
-		console.log('getUserData error');
+	} catch (error) {
+		console.log(error);
+		return null;
 	}
-	const responseData = await response.json();
-	const data = {
-		display_name: responseData.display_name,
-		user_id: responseData.id
-	};
-	return data;
 }
 
 export async function getSongs(params: string): Promise<SongDetails[]> {

--- a/src/routes/callback/+page.svelte
+++ b/src/routes/callback/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { retrieveCode } from './callback';
+	import { retrieveCode, setUserData, type UserData } from './callback';
 	import { exchangeToken, url } from '../../api/spotify/auth';
+	import { getUserData } from '../../api/spotify/service';
 
 	onMount(async () => {
 		const code = retrieveCode() as string;
 		await exchangeToken(code);
+		const userData: UserData = await getUserData();
+		await setUserData(userData);
 		window.location.replace(`${url}`);
 	});
 </script>

--- a/src/routes/callback/callback.ts
+++ b/src/routes/callback/callback.ts
@@ -4,3 +4,44 @@ export function retrieveCode() {
 	const code = urlParams.get('code');
 	return code;
 }
+
+export async function setUserData(userData: UserData) {
+	try {
+		const storedValueString: string | null = localStorage.getItem('ViBE');
+		if (storedValueString) {
+			const storedValue = JSON.parse(storedValueString);
+			storedValue.display_name = userData.display_name;
+			storedValue.user_id = userData.id;
+			localStorage.setItem('ViBE', JSON.stringify(storedValue));
+		}
+	} catch (error) {
+		console.error('error: ', error);
+	}
+}
+
+export interface UserData {
+	country: string;
+	display_name: string;
+	email: string;
+	explicit_content: {
+		filter_enabled: boolean;
+		filter_locked: boolean;
+	};
+	external_urls: {
+		spotify: string;
+	};
+	followers: {
+		href: string;
+		total: number;
+	};
+	href: string;
+	id: string;
+	images: {
+		url: string;
+		height: number;
+		width: number;
+	}[];
+	product: string;
+	type: string;
+	uri: string;
+}

--- a/tests/jest/api/auth.test.ts
+++ b/tests/jest/api/auth.test.ts
@@ -6,7 +6,6 @@ import {
 	login,
 	logout,
 	exchangeToken,
-	url,
 	refreshToken
 } from '../../../src/api/spotify/auth';
 import { localStorageMock, setItemSpy, getItemSpy, removeItemSpy } from '../../mocks/localStorage';
@@ -175,7 +174,6 @@ describe('Auth', () => {
 				user_id: ''
 			})
 		);
-		expect(replaceSpy).toHaveBeenCalledWith(`${url}`);
 	});
 	it('refreshToken localStorage', async () => {
 		await refreshToken();

--- a/tests/jest/api/spotify.test.ts
+++ b/tests/jest/api/spotify.test.ts
@@ -46,8 +46,32 @@ describe('spotify endpoint tests', () => {
 	it('getUserData', async () => {
 		const result = await getUserData();
 		expect(result).toEqual({
+			country: 'string',
 			display_name: 'mockDisplayName',
-			user_id: 'mockId'
+			email: 'string',
+			explicit_content: {
+				filter_enabled: false,
+				filter_locked: false
+			},
+			external_urls: {
+				spotify: 'string'
+			},
+			followers: {
+				href: 'string',
+				total: 0
+			},
+			href: 'string',
+			id: 'mockId',
+			images: [
+				{
+					url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228',
+					height: 300,
+					width: 300
+				}
+			],
+			product: 'string',
+			type: 'string',
+			uri: 'string'
 		});
 	});
 	it('getSongs', async () => {


### PR DESCRIPTION
## What
- retrieves user display name and user id from Spotify
- stores data in local storage
- removed check in test for redirection when exchangeToken function is called

## Why
- the application now has access to user display name for display purposes
- the application now has access to user id used for future requests
- redirection is handled in the onMount in the callback

## Impact
- Will customer experience be significantly altered? No
- Does the code change cover more than one task? No

## Testing
- tested locally by running `npm run dev`
