### PR TITLE
Added navbar, default page layout, and buttons

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,5 +16,13 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true
+	},
+	rules: {
+		// "error", // TODO: uncomment and remove comment before deployment
+		/*"no-console": [
+			{
+				"allow": ["warn", "error"]
+			}
+		]*/
 	}
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+		"lint:fix": "eslint --fix . && npm run format",
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,7 +1,7 @@
 <footer>
 	<ul class="inline">
-		<li><a href="/privacy">privacy policy</a></li>
-		<li><a href="/about">about</a></li>
+		<li><a class="underline" href="/privacy">privacy policy</a></li>
+		<li><a class="underline" href="/about">about</a></li>
 	</ul>
 	<span>powered by spotify</span>
 </footer>

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	const denylist: string[] = [];
+	const pages: string[] = ['account', 'messages', 'settings', 'styleguide'];
+
+	$: navbarVisibility = !denylist.includes($page.url.pathname);
+	$: currentPage = $page.url.pathname.slice(1);
+</script>
+
+{#if navbarVisibility}
+	<nav aria-label="Vibe">
+		<a href="/"><span class="logo">ViBE</span></a>
+
+		<ul role="menubar" aria-label="Vibe">
+			{#each pages as page}
+				<li class={page === currentPage ? 'active' : ''}>
+					<a href="/{page}">{page}</a>
+					<span aria-hidden class="format-only">{page}</span>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+{/if}
+
+<style>
+	nav,
+	ul {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+	}
+
+	nav {
+		width: 100%;
+		height: var(--h-navmain);
+		padding: var(--gap-m);
+		justify-content: flex-start;
+	}
+
+	ul {
+		gap: var(--gap-m);
+		list-style-type: none;
+	}
+
+	ul .active a {
+		font-weight: bold;
+		text-align: center;
+	}
+	ul a:first-of-type {
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+	.format-only {
+		font-weight: bold;
+		text-align: center;
+
+		opacity: 0;
+		z-index: -1;
+	}
+
+	nav .logo {
+		font-size: 1.5rem;
+	}
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import Default from '../views/Default.svelte';
+</script>
+
+<svelte:head>
+	<title>Error {$page.status} - ViBE</title>
+</svelte:head>
+
+<Default>
+	<h1>{$page.status} {$page.error?.message}</h1>
+</Default>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import Default from '../../views/Default.svelte';
+</script>
+
+<svelte:head>
+	<title>Account - ViBE</title>
+</svelte:head>
+
+<Default />

--- a/src/routes/messages/+page.svelte
+++ b/src/routes/messages/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import Default from '../../views/Default.svelte';
+</script>
+
+<svelte:head>
+	<title>Messages - ViBE</title>
+</svelte:head>
+
+<Default />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import Default from '../../views/Default.svelte';
+</script>
+
+<svelte:head>
+	<title>Settings - ViBE</title>
+</svelte:head>
+
+<Default />

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import Default from '../../views/Default.svelte';
 	import SearchButton from '../../components/SearchButton.svelte';
 	import Card from '../../components/Card.svelte';
 	import Slider from '../../components/utils/Slider/Slider.svelte';
@@ -17,62 +18,68 @@
 	<title>Styleguide - ViBE</title>
 </svelte:head>
 
-<h1>Styleguide</h1>
-
-<section id="buttons">
-	<h2>Buttons</h2>
-	<ul>
-		<li><button class="main">main button</button></li>
-		<li><button class="main invert">invert main</button></li>
-		<li><button>supporting button</button></li>
-		<li><button><span class="material-icons">support_agent</span>icon supporting</button></li>
-		<li><button class="link">link button</button></li>
-	</ul>
-</section>
-<section id="search_button">
-	<h2>Search Buttons</h2>
-	<ul>
-		<li>
-			<SearchButton state="recent" type="artist" content="Mac Miller" />
-		</li>
-		<li>
-			<SearchButton state="recent" type="song" content="Mac Miller - The Spins" />
-		</li>
-		<li style="width: 250px">
-			<SearchButton state="recent" type="song" content="Mac Miller - The Spins" />
-		</li>
-		<li style="width: 250px">
-			<SearchButton state="recent" type="song" content="Mac Miller - The Spins WWWWWWWW" />
-		</li>
-		<li style="width: 250px">
-			<SearchButton state="recent" type="song" content="Mac Miller - The Spins WWWWWWWWWWWWWWWW" />
-		</li>
-		<li style="width: 250px">
-			<SearchButton
-				state="recent"
-				type="song"
-				content="Mac Miller - The Spins WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
-			/>
-		</li>
-		<li>
-			<SearchButton state="result" type="artist" content="Mac Miller" />
-		</li>
-		<li>
-			<SearchButton state="result" type="song" content="Mac Miller - The Spins" />
-		</li>
-		<li style="width: 250px">
-			<SearchButton state="result" type="song" content="Mac Miller - The Spins" />
-		</li>
-	</ul>
-</section>
-<section>
-	<h2>Cards</h2>
-	<ul>
-		<Card songDetails={x} />
-	</ul>
-</section>
-<section>
-	<h2>Filter</h2>
-	<Slider {filter} />
-</section>
-<section style="height: 100vh;" />
+<Default>
+	<h1>Styleguide</h1>
+	<section id="buttons">
+		<h2>Buttons</h2>
+		<ul>
+			<li><button class="main">main button</button></li>
+			<li><button class="main invert">invert main</button></li>
+			<li><button>supporting button</button></li>
+			<li><button><span class="material-icons">support_agent</span>icon supporting</button></li>
+			<li><button class="link underline">link underline button</button></li>
+			<li><button class="link">link button</button></li>
+		</ul>
+	</section>
+	<section id="search_button">
+		<h2>Search Buttons</h2>
+		<ul>
+			<li>
+				<SearchButton state="recent" type="artist" content="Mac Miller" />
+			</li>
+			<li>
+				<SearchButton state="recent" type="song" content="Mac Miller - The Spins" />
+			</li>
+			<li style="width: 250px">
+				<SearchButton state="recent" type="song" content="Mac Miller - The Spins" />
+			</li>
+			<li style="width: 250px">
+				<SearchButton state="recent" type="song" content="Mac Miller - The Spins WWWWWWWW" />
+			</li>
+			<li style="width: 250px">
+				<SearchButton
+					state="recent"
+					type="song"
+					content="Mac Miller - The Spins WWWWWWWWWWWWWWWW"
+				/>
+			</li>
+			<li style="width: 250px">
+				<SearchButton
+					state="recent"
+					type="song"
+					content="Mac Miller - The Spins WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
+				/>
+			</li>
+			<li>
+				<SearchButton state="result" type="artist" content="Mac Miller" />
+			</li>
+			<li>
+				<SearchButton state="result" type="song" content="Mac Miller - The Spins" />
+			</li>
+			<li style="width: 250px">
+				<SearchButton state="result" type="song" content="Mac Miller - The Spins" />
+			</li>
+		</ul>
+	</section>
+	<section>
+		<h2>Cards</h2>
+		<ul>
+			<Card songDetails={x} />
+		</ul>
+	</section>
+	<section>
+		<h2>Filter</h2>
+		<Slider {filter} />
+	</section>
+	<section style="height: 100vh;" />
+</Default>

--- a/src/views/Default.svelte
+++ b/src/views/Default.svelte
@@ -1,0 +1,35 @@
+<script>
+	import Navbar from '../components/Navbar.svelte';
+</script>
+
+<div id="pg-layout-default">
+	<div class="navbar-container">
+		<Navbar />
+	</div>
+	<main>
+		<slot />
+	</main>
+</div>
+
+<style>
+	#pg-layout-default {
+		width: clamp(100vw, 100vw, 100vw);
+		height: clamp(100vh, 100vh, 100vh);
+
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-rows: var(--h-navmain) 1fr;
+
+		overflow: hidden;
+	}
+	.navbar-container {
+		position: sticky;
+		top: 0;
+	}
+	main {
+		min-width: 100%;
+		min-height: 100%;
+		gap: var(--gap-xl);
+		overflow-y: auto;
+	}
+</style>

--- a/static/css/button.css
+++ b/static/css/button.css
@@ -74,8 +74,17 @@ button.link,
 .button.link {
 	padding: 0;
 	margin: 0;
-	text-decoration: underline;
 	font-weight: normal;
+	text-decoration: none;
+}
+
+a:link:hover,
+button.link:hover,
+.button.link:hover,
+a:link.underline,
+button.link.underline,
+.button.link.underline {
+	text-decoration: underline;
 }
 
 button.main.invert,

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -35,15 +35,7 @@
 
 @font-face {
 	font-family: 'Inter';
-	font-style: normal;
-	font-weight: 400;
-	src: url(../fonts/inter/Inter-Regular.ttf);
-	-webkit-font-smoothing: antialiased;
-}
-
-@font-face {
-	font-family: 'Inter';
-	font-style: normal;
+	font-style: light;
 	font-weight: 200;
 	src: url(../fonts/inter/Inter-ExtraLight.ttf);
 	-webkit-font-smoothing: antialiased;
@@ -52,6 +44,13 @@
 @font-face {
 	font-family: 'Inter';
 	font-style: normal;
+	font-weight: 400;
+	src: url(../fonts/inter/Inter-Regular.ttf);
+	-webkit-font-smoothing: antialiased;
+}
+@font-face {
+	font-family: 'Inter';
+	font-style: bold;
 	font-weight: 700;
 	src: url(../fonts/inter/Inter-Bold.ttf);
 	-webkit-font-smoothing: antialiased;
@@ -59,7 +58,7 @@
 
 @font-face {
 	font-family: 'Inter';
-	font-style: normal;
+	font-style: bolder;
 	font-weight: 900;
 	src: url(../fonts/inter/Inter-Black.ttf);
 	-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## What
- Added pages for account, messages, and settings
- Fixed font-weight font-style names
- Added commented out no-console eslintrc rule
- Added default layout
- Updated styleguide page layout
- Added navbar
- Updated link style
- Renamed previous `link button` style to `link underline`

## Why
- Basic pages for project
- CSS using font-weight set via font-style did not correctly use corresponding font weight
- Preparing to turn off no-console unless type warn and error
- Enable easy use of navbar and main content
- Allow customers to easily navigate between pages
- To align with figma design of navbar

## Impact
- Will customer experience be significantly altered? No
- Does the code change cover more than one task? Yes

## Testing
- npm run lint:fix